### PR TITLE
\text -> \textrm

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,24 +2,24 @@ Package: einsum
 Type: Package
 Title: Einstein Summation
 Version: 0.0.9001
-Authors@R: person("Constantin", "Ahlmann-Eltze", email = "artjom31415@googlemail.com", 
+Authors@R: person("Constantin", "Ahlmann-Eltze", email = "artjom31415@googlemail.com",
                role = c("aut", "cre"), comment = c(ORCID = "0000-0002-3762-068X"))
-Description: Einstein summation is a concise mathematical notation that 
+Description: Einstein summation is a concise mathematical notation that
   implicitly sums over repeated indices of n-dimensional arrays. Many ordinary
   matrix operations (e.g. transpose, matrix multiplication, scalar product, 'diag()', trace etc.)
-  can be written using Einstein notation. The notation is particularly convenient for 
-  expressing operations on arrays with more than two dimensions because the 
+  can be written using Einstein notation. The notation is particularly convenient for
+  expressing operations on arrays with more than two dimensions because the
   respective operators ('tensor products') might not have a standardized name.
 License: MIT + file LICENSE
 Encoding: UTF-8
-Suggests: 
+Suggests:
     testthat,
-    mathjaxr,
     covr
 RdMacros: mathjaxr
 RoxygenNote: 7.1.0
-LinkingTo: 
+LinkingTo:
     Rcpp
-Imports: 
+Imports:
+    mathjaxr,
     Rcpp,
     glue

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,5 +2,6 @@
 
 export(einsum)
 export(einsum_generator)
+import(mathjaxr)
 importFrom(Rcpp,sourceCpp)
 useDynLib(einsum, .registration = TRUE)

--- a/man/einsum.Rd
+++ b/man/einsum.Rd
@@ -38,9 +38,9 @@ summation for arrays/matrices:
   ------------------------\tab--------------------------------------\tab----------------------------------\cr
   \code{"ij,jk->ik"} \tab \mjseqn{ Y_{ik} = \sum_{j}{A_{ij} B_{jk}}  } \tab Matrix multiplication \cr
   \code{"ij->ji"}` \tab \mjseqn{ Y = A^{T}  } \tab Transpose \cr
-  \code{"ii->i"} \tab \mjseqn{y = \text{diag}(A)} \tab Diagonal \cr
-  \code{"ii->ii"} \tab \mjseqn{Y = \text{diag}(A) I} \tab Diagonal times Identity  \cr
-  \code{"ii->"} \tab \mjseqn{y = \text{trace}(A) = \sum_i{A_{ii}} } \tab Trace \cr
+  \code{"ii->i"} \tab \mjseqn{y = \textrm{diag}(A)} \tab Diagonal \cr
+  \code{"ii->ii"} \tab \mjseqn{Y = \textrm{diag}(A) I} \tab Diagonal times Identity  \cr
+  \code{"ii->"} \tab \mjseqn{y = \textrm{trace}(A) = \sum_i{A_{ii}} } \tab Trace \cr
   \code{"ijk,mjj->i"} \tab \mjseqn{ y_i = \sum_{j}\sum_{k}\sum_{m}A_{ijk}B_{mjj}  } \tab Complex 3D operation  \cr
 }
 


### PR DESCRIPTION
I confirmed that this version could pass the following checks.

```
R CMD build einsum
R CMD INSTALL einsum_0.0.9001.tar.gz
R CMD check --as-cran einsum_0.0.9001.tar.gz
```

If there is no problem any more, could you register einsum_0.0.9001.tar.gz to CRAN?
https://cran.r-project.org/submit.html


```
> sessionInfo()
R version 4.1.0 alpha (2021-04-26 r80229)
Platform: x86_64-pc-linux-gnu (64-bit)
Running under: Debian GNU/Linux bullseye/sid

Matrix products: default
BLAS:   /usr/lib/x86_64-linux-gnu/openblas-pthread/libblas.so.3
LAPACK: /usr/lib/x86_64-linux-gnu/openblas-pthread/libopenblasp-r0.3.13.so

locale:
 [1] LC_CTYPE=en_US.UTF-8       LC_NUMERIC=C
 [3] LC_TIME=en_US.UTF-8        LC_COLLATE=en_US.UTF-8
 [5] LC_MONETARY=en_US.UTF-8    LC_MESSAGES=en_US.UTF-8
 [7] LC_PAPER=en_US.UTF-8       LC_NAME=C
 [9] LC_ADDRESS=C               LC_TELEPHONE=C
[11] LC_MEASUREMENT=en_US.UTF-8 LC_IDENTIFICATION=C

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base

loaded via a namespace (and not attached):
[1] compiler_4.1.0
```